### PR TITLE
make url in console log clickable

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,4 +35,4 @@ require("http").createServer(function(req, resp) {
   moduleServer(req, resp) || ecstatic(req, resp)
 }).listen(port, host)
 
-console.log("Module server listening on " + host + ":" + port)
+console.log("Module server listening on http://" + host + ":" + port)


### PR DESCRIPTION
Changes console.log from `Module server listening on localhost:8080` to `Module server listening on http://localhost:8080` which makes the link clickable in terminal/iTerm ;).