### PR TITLE
allow to resolve URIs starting with a forward slash

### DIFF
--- a/client.js
+++ b/client.js
@@ -39,6 +39,7 @@
     // Load a submodule of this module.
     this.require = function(name) {
       if (/^\./.test(name)) name = resolve(path, name)
+      else if (/^\//.test(name)) name = resolve("", name);
       else name = path + "/__mod/" + name
       if (name in resolved) name = resolved[name]
       if (name in loaded) return loaded[name]


### PR DESCRIPTION
Instead of this
```
<script src="/moduleserve/load.js" data-module="./my/module.js"></script>
```

I would like to do

```
<script src="/moduleserve/load.js" data-module="/my/module.js"></script>
```

The main reason is to support single page applications where routing is handled on the client.